### PR TITLE
Update README.md while running through the "Getting started" steps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,17 +115,17 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
-  jekyll (= 2.4.0)
-  jekyll-assets (= 1.0.0)
-  jekyll-watch (= 1.1)
-  liquid (= 2.6.1)
+  jekyll (>= 2.4.0)
+  jekyll-assets (>= 1.0.0)
+  jekyll-watch (>= 1.1)
+  liquid (>= 2.6.1)
   neat
-  pygments.rb (= 0.6.0)
-  rake (= 10.1)
-  redcarpet (= 3.1)
-  sass (= 3.4.2)
+  pygments.rb (>= 0.6.0)
+  rake (>= 10.1)
+  redcarpet (>= 3.1)
+  sass (>= 3.4.2)
   sass-globbing
   uglifier
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,17 +115,17 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
-  jekyll (>= 2.4.0)
-  jekyll-assets (>= 1.0.0)
-  jekyll-watch (>= 1.1)
-  liquid (>= 2.6.1)
+  jekyll (= 2.4.0)
+  jekyll-assets (= 1.0.0)
+  jekyll-watch (= 1.1)
+  liquid (= 2.6.1)
   neat
-  pygments.rb (>= 0.6.0)
-  rake (>= 10.1)
-  redcarpet (>= 3.1)
-  sass (>= 3.4.2)
+  pygments.rb (= 0.6.0)
+  rake (= 10.1)
+  redcarpet (= 3.1)
+  sass (= 3.4.2)
   sass-globbing
   uglifier
 
 BUNDLED WITH
-   1.14.3
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -8,17 +8,15 @@ permalink: readme/
 Grey Matter
 ===========
 
-Inspired by Distillery, built with Jekyll and served locally with Rake, leveraging Oomph SASS Scaffold&hellip; a start for stand-alone wireframe projects. Bourbon, Neat and [Refills](http://refills.bourbon.io/) help get us up and running with minimal styles in the way of development. 
+Inspired by Distillery, built with Jekyll and served locally with Rake, leveraging Oomph SASS Scaffold&hellip; a start for stand-alone wireframe projects. Bourbon, Neat and [Refills](http://refills.bourbon.io/) help get us up and running with minimal styles in the way of development.
 
 
 ## Distillery
-[Distillery](https://github.com/thinkshout/distillery/tree/master/) is a starter kit for creating wireframes with Jekyll 2.4. I borrowed this code from them as a way to have a simple Jekyll set up with Rake for local watching/serving. Rake adds SASS globbing to this build, allowing us in SASS to use: 
+[Distillery](https://github.com/thinkshout/distillery/tree/master/) is a starter kit for creating wireframes with Jekyll 2.4. I borrowed this code from them as a way to have a simple Jekyll set up with Rake for local watching/serving. Rake adds SASS globbing to this build, allowing us in SASS to use:
 
-{% highlight CSS %}
-@import "component/*";
-{% endhighlight %}
+`@import "component/*";`
 
-Everything inside that folder will be added and watched for changes. 
+Everything inside that folder will be added and watched for changes.
 
 
 ## Getting started
@@ -28,19 +26,24 @@ To get up and running:
 ### Install dependencies
 Navigate to this folder in your Terminal, then:
 
-{% highlight TeX linenos %}
+```
 $ gem install bundler
 $ bundle install
-{% endhighlight %}
+```
 
-Review the Gemfile to see which versions of Jekyll, Rake and SASS are required as minimum dependencies. 
+Navigate to the _sass/libraries folder, then run:
+
+```
+$ bourbon install
+$ neat install
+```
+
+Review the Gemfile to see which versions of Jekyll, Rake and SASS are required as minimum dependencies.
 
 
 ### To run the local server
 
-{% highlight TeX %}
-$ rake serve
-{% endhighlight %}
+`$ rake serve`
 
 The server is available at `http://localhost:4000`. If the compiled file URLs need to be prefixed, add a prefix to the `rakefile` line 21, and serve from that project root as well, i.e. `http://localhost:4000/project`. When you upload the sites content to a server, all URLs will be prefixed with `/project`.
 
@@ -50,13 +53,13 @@ Any folder prefixed with an underscore is used as a build folder only, it is not
 
 Use `_includes` like you would use partials in PHP for repetitive elements like headers, footer, nav, etc…
 
-Use `_layouts` to control larger templates. Distillery ships with an example page and a post. Variables use a `{# double brace #}` syntax, and refer to simple text declarations at the top of page files. `default.html` is the larger template and includes calls for a header and footer. `page.html` is a partial, which renders where the {% raw %}`{{ content }}`{% endraw %} call is made. 
+Use `_layouts` to control larger templates. Distillery ships with an example page and a post. Variables use a `{# double brace #}` syntax, and refer to simple text declarations at the top of page files. `default.html` is the larger template and includes calls for a header and footer. `page.html` is a partial, which renders where the {% raw %}`{{ content }}`{% endraw %} call is made.
 
-Page files live at the site root. All rendered HTML and assets go into the `_site` folder by default, from which they are served in your browser. Pages can also be nested in folders and will be rendered as such. 
+Page files live at the site root. All rendered HTML and assets go into the `_site` folder by default, from which they are served in your browser. Pages can also be nested in folders and will be rendered as such.
 
 More in depth Jekyll instructions here from [JekyllRB][(https://jekyllrb.com/).
 
-[Refills]({{ 'refills' | prepend: site.baseurl }}) components are included in this repo as Prototyping patterns. 
+[Refills]({{ 'refills' | prepend: site.baseurl }}) components are included in this repo as Prototyping patterns.
 
 
 ## Markdown


### PR DESCRIPTION
Update coded samples with GitHub Markdown, and added the `bourbon install` and `neat install` steps, so that when you run `rake serve` you don't get an error. 

<img width="853" alt="screen shot 2017-02-06 at 10 56 59 am" src="https://cloud.githubusercontent.com/assets/7534048/22654538/07418548-ec5b-11e6-929f-ae21f59bef02.png">

@jhogue note that when I ran the install, there were some updates to the `Gemfile.lock` but I didn't update those here as I didn't know if you wanted it updated. 